### PR TITLE
Update prometheus target availability query

### DIFF
--- a/plugins/prometheus/targets/availability/plugin.go
+++ b/plugins/prometheus/targets/availability/plugin.go
@@ -16,7 +16,7 @@ const (
 )
 
 var queryTpl = template.Must(template.New("").Option("missingkey=error").Parse(`
-sum(count_over_time((up{ {{.filter}} } == 0)[{{"{{ .window }}"}}:]))
+sum(count_over_time((up{ {{.filter}} } == 0)[{{"{{ .window }}"}}:])) or vector(0)
 /
 sum(count_over_time((up{ {{.filter}} })[{{"{{ .window }}"}}:]))
 `))

--- a/plugins/prometheus/targets/availability/plugin_test.go
+++ b/plugins/prometheus/targets/availability/plugin_test.go
@@ -20,7 +20,7 @@ func TestSLIPlugin(t *testing.T) {
 		"Having no filter option should return the correct query.": {
 			options: map[string]string{},
 			expQuery: `
-sum(count_over_time((up{  } == 0)[{{ .window }}:]))
+sum(count_over_time((up{  } == 0)[{{ .window }}:])) or vector(0)
 /
 sum(count_over_time((up{  })[{{ .window }}:]))
 `,
@@ -29,7 +29,7 @@ sum(count_over_time((up{  })[{{ .window }}:]))
 		"Having filter option should return the correct query.": {
 			options: map[string]string{"filter": `k1="v1",k2="v2"`},
 			expQuery: `
-sum(count_over_time((up{ k1="v1",k2="v2" } == 0)[{{ .window }}:]))
+sum(count_over_time((up{ k1="v1",k2="v2" } == 0)[{{ .window }}:])) or vector(0)
 /
 sum(count_over_time((up{ k1="v1",k2="v2" })[{{ .window }}:]))
 `,


### PR DESCRIPTION
The reasoning behind this is the following: If the equation in the original query is not valid (`== 0`) then we get `No data` instead of 0. By adding the `vector(0)` we get rid of this problem