### PR TITLE
nginx-ingress sli plugin

### DIFF
--- a/plugins/kubernetes/nginx-ingress/availability/README.md
+++ b/plugins/kubernetes/nginx-ingress/availability/README.md
@@ -1,0 +1,35 @@
+# Kubernetes nginx-ingress availability
+
+Availability plugin for services using the nginx ingress controller for exposure.
+
+Uses the HTTP response status codes to measure the events as good or bad. It counts an error event when HTTP response status code is >=500 or 429.
+
+In other words, it counts as good events the <500 and !429 HTTP response status codes.
+
+## Options
+
+- `filter`: (**Optional**) A prometheus filter string using concatenated labels (e.g: `job="k8sapiserver",env="production",cluster="k8s-42"`)
+
+## Metric requirements
+
+- `nginx_ingress_controller_requests`.
+
+## Usage examples
+
+### Without filter
+
+```yaml
+sli:
+  plugin:
+    id: "sloth-common/kubernetes/nginx-ingress/availability"
+```
+
+### With custom filter
+
+```yaml
+sli:
+  plugin:
+    id: "sloth-common/kubernetes/nginx-ingress/availability"
+    options:
+      filter: ingress="k8sapiserver",host="my.example.com",exported_namespace="my-production-app"
+```

--- a/plugins/kubernetes/nginx-ingress/availability/plugin.go
+++ b/plugins/kubernetes/nginx-ingress/availability/plugin.go
@@ -1,0 +1,69 @@
+package availability
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+const (
+	// SLIPluginVersion is the version of the plugin spec.
+	SLIPluginVersion = "prometheus/v1"
+	// SLIPluginID is the registering ID of the plugin.
+	SLIPluginID = "sloth-common/kubernetes/nginx-ingress/availability"
+)
+
+var queryTpl = template.Must(template.New("").Option("missingkey=error").Parse(`
+sum(rate(nginx_ingress_controller_requests{ {{.filterError}}status=~"(5..|429)" }[{{"{{.window}}"}}]))
+/
+sum(rate(nginx_ingress_controller_requests{ {{.filterTotal}} }[{{"{{.window}}"}}]))
+`))
+
+// SLIPlugin will return a query that will return the availability error based on the ingress status response codes.
+// Counts as an error event the requests that have >=500 and 429 status codes.
+func SLIPlugin(ctx context.Context, meta, labels, options map[string]string) (string, error) {
+	filter, err := getFilter(options)
+	if err != nil {
+		return "", fmt.Errorf("could not get filter: %w", err)
+	}
+
+	filterTotal := filter
+	filterError := filter
+	if filterError != "" {
+		filterError = filter + ","
+	}
+
+	// Create query.
+	var b bytes.Buffer
+	data := map[string]string{
+		"filterError": filterError,
+		"filterTotal": filterTotal,
+	}
+	err = queryTpl.Execute(&b, data)
+	if err != nil {
+		return "", fmt.Errorf("could not render query template: %w", err)
+	}
+
+	return b.String(), nil
+}
+
+var filterRegex = regexp.MustCompile(`(?m)^{?([^=]+="[^=,"]+",)*([^=]+="[^=,"]+")$`)
+
+func getFilter(options map[string]string) (string, error) {
+	filter, ok := options["filter"]
+	if !ok || (ok && filter == "") {
+		return "", nil
+	}
+
+	// Sanitize and check filter.
+	filter = strings.Trim(filter, "{},")
+	match := filterRegex.MatchString(filter)
+	if !match {
+		return "", fmt.Errorf("invalid prometheus filter: %s", filter)
+	}
+
+	return filter, nil
+}

--- a/plugins/kubernetes/nginx-ingress/availability/plugin.go
+++ b/plugins/kubernetes/nginx-ingress/availability/plugin.go
@@ -20,6 +20,7 @@ var queryTpl = template.Must(template.New("").Option("missingkey=error").Parse(`
 sum(rate(nginx_ingress_controller_requests{ {{.filterError}}status=~"(5..|429)" }[{{"{{.window}}"}}]))
 /
 sum(rate(nginx_ingress_controller_requests{ {{.filterTotal}} }[{{"{{.window}}"}}]))
+or on() vector(0)
 `))
 
 // SLIPlugin will return a query that will return the availability error based on the ingress status response codes.

--- a/plugins/kubernetes/nginx-ingress/availability/plugin_test.go
+++ b/plugins/kubernetes/nginx-ingress/availability/plugin_test.go
@@ -23,27 +23,27 @@ func TestSLIPlugin(t *testing.T) {
 		},
 
 		"Not having a filter shouldn't fail and return the correct query.": {
-			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{  }[{{.window}}]))\n",
+			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{  }[{{.window}}]))\nor on() vector(0)\n",
 		},
 
 		"Having a filter should return the query with the filters.": {
 			options:  map[string]string{"filter": `k1="v2",k2="v2"`},
-			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\",status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\" }[{{.window}}]))\n",
+			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\",status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\" }[{{.window}}]))\nor on() vector(0)\n",
 		},
 
 		"Having a filter with `{}` should return the query with the filters.": {
 			options:  map[string]string{"filter": `{k1="v2",k2="v2"}`},
-			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\",status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\" }[{{.window}}]))\n",
+			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\",status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\" }[{{.window}}]))\nor on() vector(0)\n",
 		},
 
 		"Having a filter with `,` should return the query with the filters.": {
 			options:  map[string]string{"filter": `k1="v2",k2="v2",`},
-			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\",status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\" }[{{.window}}]))\n",
+			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\",status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\" }[{{.window}}]))\nor on() vector(0)\n",
 		},
 
 		"Having a filter with `{}` and `,` should return the query with the filters.": {
 			options:  map[string]string{"filter": `{k1="v2",k2="v2",}`},
-			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\",status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\" }[{{.window}}]))\n",
+			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\",status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\" }[{{.window}}])\nor on() vector(0)\n",
 		},
 	}
 

--- a/plugins/kubernetes/nginx-ingress/availability/plugin_test.go
+++ b/plugins/kubernetes/nginx-ingress/availability/plugin_test.go
@@ -1,0 +1,63 @@
+package availability_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/slok/sloth-common-sli-plugins/plugins/kubernetes/apiserver/availability"
+)
+
+func TestSLIPlugin(t *testing.T) {
+	tests := map[string]struct {
+		meta     map[string]string
+		labels   map[string]string
+		options  map[string]string
+		expQuery string
+		expErr   bool
+	}{
+		"Having a wrong filter, it should fail.": {
+			options: map[string]string{"filter": "something="},
+			expErr:  true,
+		},
+
+		"Not having a filter shouldn't fail and return the correct query.": {
+			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{  }[{{.window}}]))\n",
+		},
+
+		"Having a filter should return the query with the filters.": {
+			options:  map[string]string{"filter": `k1="v2",k2="v2"`},
+			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\",status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\" }[{{.window}}]))\n",
+		},
+
+		"Having a filter with `{}` should return the query with the filters.": {
+			options:  map[string]string{"filter": `{k1="v2",k2="v2"}`},
+			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\",status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\" }[{{.window}}]))\n",
+		},
+
+		"Having a filter with `,` should return the query with the filters.": {
+			options:  map[string]string{"filter": `k1="v2",k2="v2",`},
+			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\",status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\" }[{{.window}}]))\n",
+		},
+
+		"Having a filter with `{}` and `,` should return the query with the filters.": {
+			options:  map[string]string{"filter": `{k1="v2",k2="v2",}`},
+			expQuery: "\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\",status=~\"(5..|429)\" }[{{.window}}]))\n/\nsum(rate(nginx_ingress_controller_requests{ k1=\"v2\",k2=\"v2\" }[{{.window}}]))\n",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			gotQuery, err := availability.SLIPlugin(context.TODO(), test.meta, test.labels, test.options)
+
+			if test.expErr {
+				assert.Error(err)
+			} else if assert.NoError(err) {
+				assert.Equal(test.expQuery, gotQuery)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Lazily adapted from the apiserver example given to use the nginx-ingress metrics rules

# What it do?

Adds a simple SLI plugin that uses the default nginx metrics for ingress controllers so people can throw an SLO that reflects their ingress quite easily.

# How it do?

```yaml
...
slos:
  - name: "my-public-ingress"
    objective: 99.9
    description: HTTP Availability for my ingress
    sli:
      plugin:
        id: "sloth-common/kubernetes/nginx-ingress/availability"
        options:
          filter: ingress="public-ingress",exported_namespace="my-awesome-website"
```

